### PR TITLE
Fix "zip" when constructing t_amounts when there are multiple balance_change entries

### DIFF
--- a/beancount_balancechange/balance_change.py
+++ b/beancount_balancechange/balance_change.py
@@ -68,8 +68,8 @@ def balance_change(entries, options_map):
                                  if is_balance_change_entry(entry)]
 
     t1_dates = [entry.meta.get('since') for entry in balance_change_assertions]
-    asserted_accounts = {get_account_from_entry(entry) for entry in balance_change_assertions}
-    asserted_currencies = {get_expected_amount_from_entry(entry).currency for entry in balance_change_assertions}
+    asserted_accounts = [get_account_from_entry(entry) for entry in balance_change_assertions]
+    asserted_currencies = [get_expected_amount_from_entry(entry).currency for entry in balance_change_assertions]
     t1_amounts = {(bank,date,currency): "NaN" for bank,date,currency in zip(asserted_accounts, t1_dates, asserted_currencies)}
 
     # Add all children accounts of an asserted account to be calculated as well,

--- a/tests/test_balance_change.py
+++ b/tests/test_balance_change.py
@@ -32,6 +32,29 @@ class TestBalanceChange(cmptest.TestCase):
         self.assertEqual(len(errors), 0)
 
     @loader.load_doc(expect_errors=False)
+    def test_balance_change_multiple_balance_changes(self, entries, _, options_map):
+        """
+        2020-01-01 open Equity:Opening-Balances GBP, USD
+        2020-01-01 open Assets:BankA GBP, USD
+        2020-01-01 open Assets:BankB GBP, USD
+
+        2020-01-03 txn "Example"
+           Assets:BankA 50 GBP
+           Equity:Opening-Balances -50 GBP
+
+        2020-01-03 txn "Example"
+           Assets:BankB 100 GBP
+           Equity:Opening-Balances -100 GBP
+
+        2020-01-07 custom "balance_change" Assets:BankA 50 GBP
+            since: 2020-01-02
+        2020-01-07 custom "balance_change" Assets:BankB 100 GBP
+            since: 2020-01-02
+        """
+        new_entries, errors = balance_change(entries, options_map)
+        self.assertEqual(len(errors), 0)
+
+    @loader.load_doc(expect_errors=False)
     def test_balance_change_multi_txs(self, entries, _, options_map):
         """
         2020-01-01 open Equity:Opening-Balances GBP, USD


### PR DESCRIPTION
The set comprehensions to construct `asserted_accounts` and `asserted_currencies` would merge duplicate account and currency values. This could result in the `zip` dropping entries, as highlighted by the new unit test.